### PR TITLE
Implement social media backend with caching

### DIFF
--- a/.env
+++ b/.env
@@ -6,4 +6,5 @@ DB_NAME=thesis_db
 
 REDIS_ADDR=localhost:6379
 JWT_SECRET=your_secret_key
-ENABLE_ADAPTIVE_TTL=false
+CACHE_ENABLED=true
+ADAPTIVE_TTL_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It simulates core social media functionalities such as user signup/login, follow
   - Fan-out on Write
   - Trending Cache
   - Profile Cache
-  - Adaptive TTL for timelines (toggle via `ENABLE_ADAPTIVE_TTL`)
+  - Adaptive TTL for timelines (toggle via `ADAPTIVE_TTL_ENABLED`)
 
 ---
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -38,17 +38,15 @@ func main() {
 	fmt.Println("Test Redis Key:", val)
 
 	// Public routes
-	http.HandleFunc("/signup", handler.Signup)
-	http.HandleFunc("/login", handler.Login)
+	http.HandleFunc("/auth/register", handler.Register)
+	http.HandleFunc("/auth/login", handler.Login)
 
 	// Protected routes
 	http.Handle("/posts", middleware.AuthMiddleware(http.HandlerFunc(handler.CreatePost)))
 	http.Handle("/posts/", middleware.AuthMiddleware(http.HandlerFunc(handler.LikePost)))
 	http.Handle("/follow/", middleware.AuthMiddleware(http.HandlerFunc(handler.FollowUser)))
-	http.Handle("/timeline/db", middleware.AuthMiddleware(http.HandlerFunc(handler.GetTimelineFromDB)))
-	http.Handle("/timeline/cache", middleware.AuthMiddleware(http.HandlerFunc(handler.GetTimelineWithCache)))
-	http.Handle("/trending/cache", http.HandlerFunc(handler.GetTrendingWithCache))
-	http.Handle("/trending/db", http.HandlerFunc(handler.GetTrendingFromDB))
+	http.Handle("/timeline", middleware.AuthMiddleware(http.HandlerFunc(handler.GetTimeline)))
+	http.Handle("/trending", http.HandlerFunc(handler.GetTrending))
 	http.Handle("/profile/", http.HandlerFunc(handler.GetProfile))
 
 	fmt.Println("Server running on :8080")

--- a/internal/cache/profile.go
+++ b/internal/cache/profile.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/config"
 	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/db"
+	"github.com/redis/go-redis/v9"
 )
 
-const profileTTL = 10 * time.Minute
+const profileTTL = 5 * time.Minute
 
 func SetProfileCache(profile db.UserProfile) error {
 	key := fmt.Sprintf("profile:%d", profile.ID)
@@ -24,18 +25,21 @@ func SetProfileCache(profile db.UserProfile) error {
 	return config.RedisClient.Set(ctx, key, data, profileTTL).Err()
 }
 
-func GetProfileCache(userID int64) (*db.UserProfile, error) {
+func GetProfileCache(userID int64) (*db.UserProfile, bool, error) {
 	key := fmt.Sprintf("profile:%d", userID)
 
 	val, err := config.RedisClient.Get(context.Background(), key).Result()
+	if err == redis.Nil {
+		return nil, false, nil
+	}
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var profile db.UserProfile
 	if err := json.Unmarshal([]byte(val), &profile); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return &profile, nil
+	return &profile, true, nil
 }

--- a/internal/cache/timeline.go
+++ b/internal/cache/timeline.go
@@ -48,26 +48,26 @@ func getAdaptiveTTL(postCount int) time.Duration {
 	return newTTL
 }
 
-func GetTimelineFromCache(userID int64) ([]db.Post, error) {
+func GetTimelineFromCache(userID int64) ([]db.Post, bool, error) {
 	key := fmt.Sprintf("timeline:%d", userID)
 
 	ctx := context.Background()
 	val, err := config.RedisClient.Get(ctx, key).Result()
 	if err == redis.Nil {
 		// cache miss
-		return nil, nil
+		return nil, false, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var posts []db.Post
 	err = json.Unmarshal([]byte(val), &posts)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return posts, nil
+	return posts, true, nil
 }
 
 func SetTimelineToCache(userID int64, posts []db.Post) error {

--- a/internal/cache/trending.go
+++ b/internal/cache/trending.go
@@ -2,13 +2,17 @@ package cache
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/config"
+	"github.com/redis/go-redis/v9"
 )
 
 const trendingKey = "trending"
+const trendingListTTL = 5 * time.Minute
 
 func IncrementTrendingScore(postID int64) error {
 	ctx := context.Background()
@@ -30,4 +34,30 @@ func GetTopTrendingPosts(limit int64) ([]int64, error) {
 	}
 
 	return ids, nil
+}
+
+// GetTopTrendingCached returns trending post IDs and whether it was a cache hit.
+func GetTopTrendingCached(limit int64) ([]int64, bool, error) {
+	cacheKey := fmt.Sprintf("trending:top:%d", limit)
+	ctx := context.Background()
+
+	val, err := config.RedisClient.Get(ctx, cacheKey).Result()
+	if err == nil {
+		var ids []int64
+		if err := json.Unmarshal([]byte(val), &ids); err == nil {
+			return ids, true, nil
+		}
+	}
+	if err != nil && err != redis.Nil {
+		return nil, false, err
+	}
+
+	ids, err := GetTopTrendingPosts(limit)
+	if err != nil {
+		return nil, false, err
+	}
+
+	data, _ := json.Marshal(ids)
+	_ = config.RedisClient.Set(ctx, cacheKey, data, trendingListTTL).Err()
+	return ids, false, nil
 }

--- a/internal/config/db.go
+++ b/internal/config/db.go
@@ -61,12 +61,22 @@ func createTables() error {
 	);`
 
 	postTable := `
-	CREATE TABLE IF NOT EXISTS posts (
-		id SERIAL PRIMARY KEY,
-		user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-		content TEXT NOT NULL,
-		created_at TIMESTAMP DEFAULT now()
-	);`
+        CREATE TABLE IF NOT EXISTS posts (
+                id SERIAL PRIMARY KEY,
+                user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                content TEXT NOT NULL,
+                likes INT DEFAULT 0,
+                created_at TIMESTAMP DEFAULT now()
+        );`
+
+	likeTable := `
+        CREATE TABLE IF NOT EXISTS likes (
+                id SERIAL PRIMARY KEY,
+                user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                post_id INT NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+                created_at TIMESTAMP DEFAULT now(),
+                UNIQUE(user_id, post_id)
+        );`
 
 	followTable := `
 	CREATE TABLE IF NOT EXISTS follows (
@@ -85,6 +95,11 @@ func createTables() error {
 		return err
 	}
 	_, err = DB.Exec(followTable)
+	if err != nil {
+		return err
+	}
+
+	_, err = DB.Exec(likeTable)
 	if err != nil {
 		return err
 	}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-var EnableCaching = true
+// EnableCaching controls whether Redis should be used.
+var EnableCaching = os.Getenv("CACHE_ENABLED") != "false"
 
 // EnableAdaptiveTTL toggles dynamic TTL calculation for timelines.
-// Controlled via the ENABLE_ADAPTIVE_TTL environment variable.
-var EnableAdaptiveTTL = os.Getenv("ENABLE_ADAPTIVE_TTL") == "true"
+var EnableAdaptiveTTL = os.Getenv("ADAPTIVE_TTL_ENABLED") == "true"
 
 // Timeline cache TTL settings used when adaptive mode is enabled.
 const (

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -140,6 +140,11 @@ func LikePost(ctx context.Context, userID, postID int64) error {
 	c, cancel := context.WithTimeout(ctx, dbTimeout)
 	defer cancel()
 	_, err := config.DB.ExecContext(c, query, userID, postID)
+	if err != nil {
+		return err
+	}
+
+	_, err = config.DB.ExecContext(c, "UPDATE posts SET likes = likes + 1 WHERE id=$1", postID)
 	return err
 }
 

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -13,7 +13,7 @@ type SignupRequest struct {
 	Password string `json:"password"`
 }
 
-func Signup(w http.ResponseWriter, r *http.Request) {
+func Register(w http.ResponseWriter, r *http.Request) {
 	var req SignupRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request", http.StatusBadRequest)
@@ -35,7 +35,7 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	w.Write([]byte("Signup successful"))
+	w.Write([]byte("Registered successfully"))
 }
 
 type LoginRequest struct {

--- a/internal/handler/profile_handler.go
+++ b/internal/handler/profile_handler.go
@@ -27,10 +27,16 @@ func GetProfile(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 	defer cancel()
 
-	profile, err := service.GetUserProfile(ctx, userID)
+	profile, hit, err := service.GetUserProfile(ctx, userID)
 	if err != nil {
 		http.Error(w, "Failed to get profile", http.StatusInternalServerError)
 		return
+	}
+
+	if hit {
+		w.Header().Set("X-Cache", "HIT")
+	} else {
+		w.Header().Set("X-Cache", "MISS")
 	}
 
 	json.NewEncoder(w).Encode(profile)

--- a/internal/handler/timeline_handler.go
+++ b/internal/handler/timeline_handler.go
@@ -12,12 +12,12 @@ import (
 	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/service"
 )
 
-func GetTimelineFromDB(w http.ResponseWriter, r *http.Request) {
+func GetTimeline(w http.ResponseWriter, r *http.Request) {
 	userID := r.Context().Value(middleware.ContextUserID).(int64)
 	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 	defer cancel()
 
-	posts, err := service.GetTimelinePosts(ctx, userID)
+	posts, hit, err := service.GetTimeline(ctx, userID)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			http.Error(w, "Timeline request timed out", http.StatusGatewayTimeout)
@@ -27,28 +27,16 @@ func GetTimelineFromDB(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	json.NewEncoder(w).Encode(posts)
-}
-
-func GetTimelineWithCache(w http.ResponseWriter, r *http.Request) {
-	userID := r.Context().Value(middleware.ContextUserID).(int64)
-	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
-	defer cancel()
-
-	posts, err := service.GetTimelineWithCache(ctx, userID)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			http.Error(w, "Timeline request timed out", http.StatusGatewayTimeout)
-		} else {
-			http.Error(w, "Failed to fetch timeline with cache", http.StatusInternalServerError)
-		}
-		return
-	}
-
 	if posts == nil {
 		posts = []db.Post{}
 	}
 
-	w.WriteHeader(http.StatusOK) // ✅ Make sure status code is 200
+	if hit {
+		w.Header().Set("X-Cache", "HIT")
+	} else {
+		w.Header().Set("X-Cache", "MISS")
+	}
+
+	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(posts)
 }

--- a/internal/service/timeline_service.go
+++ b/internal/service/timeline_service.go
@@ -1,40 +1,45 @@
 package service
 
 import (
-       "context"
-       "log"
+	"context"
+	"log"
 
-       "github.com/redis/go-redis/v9"
-       "github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/cache"
-       "github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/db"
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/cache"
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/config"
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/db"
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/pkg/utils"
+	"github.com/redis/go-redis/v9"
 )
 
 func GetTimelinePosts(ctx context.Context, userID int64) ([]db.Post, error) {
-       posts, err := db.GetTimelinePosts(ctx, userID)
-       if err != nil {
-               log.Printf("Timeline DB error: %v", err)
-       }
-       return posts, err
+	posts, err := db.GetTimelinePosts(ctx, userID)
+	if err != nil {
+		log.Printf("Timeline DB error: %v", err)
+	}
+	return posts, err
 }
 
-func GetTimelineWithCache(ctx context.Context, userID int64) ([]db.Post, error) {
-       posts, err := cache.GetTimelineFromCache(userID)
-       if err != nil && err != redis.Nil {
-               log.Printf("Redis GetTimelineFromCache error: %v", err)
-               return nil, err
-       }
-	if posts != nil {
-		return posts, nil
+func GetTimeline(ctx context.Context, userID int64) ([]db.Post, bool, error) {
+	if config.EnableCaching && utils.UseCache(userID) {
+		posts, hit, err := cache.GetTimelineFromCache(userID)
+		if err != nil && err != redis.Nil {
+			log.Printf("Redis GetTimelineFromCache error: %v", err)
+			return nil, false, err
+		}
+		if hit {
+			return posts, true, nil
+		}
+
+		posts, err = db.GetTimelinePosts(ctx, userID)
+		if err != nil {
+			log.Printf("DB GetTimelinePosts error: %v", err)
+			return nil, false, err
+		}
+
+		_ = cache.SetTimelineToCache(userID, posts)
+		return posts, false, nil
 	}
 
-	// Cache miss — Fetch from DB
-       posts, err = db.GetTimelinePosts(ctx, userID)
-       if err != nil {
-               log.Printf("DB GetTimelinePosts error: %v", err)
-               return nil, err
-       }
-
-	_ = cache.SetTimelineToCache(userID, posts)
-
-	return posts, nil
+	posts, err := db.GetTimelinePosts(ctx, userID)
+	return posts, false, err
 }

--- a/internal/service/trending_service.go
+++ b/internal/service/trending_service.go
@@ -1,1 +1,23 @@
 package service
+
+import (
+	"context"
+
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/cache"
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/config"
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/db"
+)
+
+// GetTrendingPosts returns IDs of trending posts and whether they were served from cache.
+func GetTrendingPosts(ctx context.Context, limit int64) ([]int64, bool, error) {
+	if config.EnableCaching {
+		ids, hit, err := cache.GetTopTrendingCached(limit)
+		if err == nil {
+			return ids, hit, nil
+		}
+		// fallback to DB in case of error
+	}
+
+	ids, err := db.GetTopTrendingFromDB(ctx, limit)
+	return ids, false, err
+}

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -4,24 +4,33 @@ import (
 	"context"
 
 	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/cache"
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/config"
 	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/internal/db"
+	"github.com/quocnguyenhung/caching-optimization-in-high-performance-systems/pkg/utils"
+	"github.com/redis/go-redis/v9"
 )
 
-func GetUserProfile(ctx context.Context, userID int64) (*db.UserProfile, error) {
-	// First try cache
-	profile, err := cache.GetProfileCache(userID)
-	if err == nil && profile != nil {
-		return profile, nil
+func GetUserProfile(ctx context.Context, userID int64) (*db.UserProfile, bool, error) {
+	if config.EnableCaching && utils.UseCache(userID) {
+		profile, hit, err := cache.GetProfileCache(userID)
+		if err == nil && hit {
+			return profile, true, nil
+		}
+		if err != nil && err != redis.Nil {
+			return nil, false, err
+		}
 	}
 
 	// Fallback to DB
-	profile, err = db.GetUserProfileFromDB(ctx, userID)
+	profile, err := db.GetUserProfileFromDB(ctx, userID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// Update cache
-	_ = cache.SetProfileCache(*profile)
+	if config.EnableCaching {
+		_ = cache.SetProfileCache(*profile)
+	}
 
-	return profile, nil
+	return profile, false, nil
 }

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -1,0 +1,9 @@
+package utils
+
+// hotUsers simulates active users whose data is likely cached.
+var hotUsers = map[int64]bool{1: true, 2: true, 3: true}
+
+// UseCache returns true if the user should use the cache layer.
+func UseCache(userID int64) bool {
+	return hotUsers[userID]
+}


### PR DESCRIPTION
## Summary
- add PostgreSQL schema for likes and post like counts
- configure cache toggles via `CACHE_ENABLED` and `ADAPTIVE_TTL_ENABLED`
- add hot user cache utility
- return `X-Cache` headers for timeline, trending, and profile endpoints
- implement unified `/auth/*`, `/timeline`, `/trending` routes
- add support for caching in services and handlers

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_b_687bc2188718832b94be7fccd28eb75d